### PR TITLE
Improve handling of resource pack menu when no behavior pack is loaded

### DIFF
--- a/src/renderer/components/sidebar/content/Explorer.vue
+++ b/src/renderer/components/sidebar/content/Explorer.vue
@@ -4,7 +4,8 @@
 			v-if="
 				selected !== undefined &&
 					selected !== '/@NO-RP@/' &&
-					selected !== '/@NO-DEPENDENCY@/'
+					selected !== '/@NO-DEPENDENCY@/' &&
+					selected !== '/@NO-BP@/'
 			"
 		>
 			<component
@@ -45,7 +46,8 @@
 				loaded_file_defs &&
 					selected !== undefined &&
 					selected !== '/@NO-RP@/' &&
-					selected !== '/@NO-DEPENDENCY@/'
+					selected !== '/@NO-DEPENDENCY@/' &&
+					selected !== '/@NO-BP@/'
 			"
 			:files="directory"
 			:project="selected"
@@ -65,6 +67,11 @@
 
 			<v-btn @click="createRP" style="margin-right: 4px;">Create</v-btn
 			><v-btn color="primary" @click="linkRP">Link</v-btn>
+		</div>
+		<div v-else-if="selected === '/@NO-BP@/'" style="padding: 4px;">
+			<p style="word-break: break-word;">
+				Please load a behavior pack before trying to link a resource pack.
+			</p>
 		</div>
 		<div v-else style="padding: 4px; word-break: break-word;">
 			<p style="word-break: break-word;">
@@ -246,7 +253,8 @@ export default {
 			if (
 				dir === undefined ||
 				dir === '/@NO-RP@/' ||
-				dir === '/@NO-DEPENDENCY@/'
+				dir === '/@NO-DEPENDENCY@/' ||
+				dir === '/@NO-BP@/'
 			)
 				return lw.close()
 			if (dir !== this.selected) {

--- a/src/renderer/scripts/Utilities/FindRP.ts
+++ b/src/renderer/scripts/Utilities/FindRP.ts
@@ -8,13 +8,20 @@ import Store from '../../store/index'
 let last_selected: string
 let last_result: string
 
-export const NEGATIVE_RESPONSES = ['/@NO-RP@/', '/@NO-DEPENDENCY@/']
+export const NEGATIVE_RESPONSES = [
+	'/@NO-RP@/',
+	'/@NO-DEPENDENCY@/',
+	'/@NO-BP@/'
+]
+
 export function setRP(val: string) {
 	last_result = val
 }
+
 export default async function findRP() {
 	let selected = TabSystem.project
-	if (selected === undefined) return '/@NO-RP@/'
+	if (selected === undefined)
+		return '/@NO-BP@/'
 	if (selected === last_selected && last_result !== undefined)
 		return last_result
 	last_selected = selected


### PR DESCRIPTION
## Description
Added new `/@NO-BP@/` negative response for the resource pack tab. This only is returned if no behavior pack is loaded in the editor.

## Motivation and Context
- Fixes #143 
- Prevents an error that can occur when clicking 'unlink' if no BP is loaded