### PR TITLE
Arrow consistency with other editors

### DIFF
--- a/src/renderer/components/editor_shell/JsonEditor/ObjectKey.vue
+++ b/src/renderer/components/editor_shell/JsonEditor/ObjectKey.vue
@@ -25,7 +25,7 @@
 						(!inversed_arrows && !node_context.open)
 				"
 				small
-				>mdi-chevron-down</v-icon
+				>mdi-chevron-right</v-icon
 			>
 			<v-icon
 				v-if="
@@ -33,7 +33,7 @@
 						(inversed_arrows && !node_context.open)
 				"
 				small
-				>mdi-chevron-up</v-icon
+				>mdi-chevron-down</v-icon
 			>
 		</v-btn>
 


### PR DESCRIPTION
Let me preface this will a huge thank you for creating this wonderful editor! I love the work you've done.

## Description

Other popular editors, specifically VS Code, Atom, IntelliJ, and Visual Studio use right for closed and down for open. I personally find down for closed and up for open extremely unintuitive. Swapping the arrow directions in the settings (something I don't think needs to be a setting) still feels very off.

## Screenshots

VS Code
![image](https://user-images.githubusercontent.com/12021069/77830215-01570500-70f5-11ea-85f1-d7881c676a94.png)

Atom
![image](https://user-images.githubusercontent.com/12021069/77830087-17b09100-70f4-11ea-82c3-30b71f5934e2.png)

bridge.
![image](https://user-images.githubusercontent.com/12021069/77830146-81c93600-70f4-11ea-9f4f-be7e0bc456c0.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes require updating to the plugin documentation.
