### PR TITLE
Added lightning to damage types

### DIFF
--- a/static/auto_completions/general.json
+++ b/static/auto_completions/general.json
@@ -96,7 +96,7 @@
         "minecart_chest", "horse", "minecart_hopper", "container"
     ],
     "damage_type": [
-        "override", "contact", "none", "lava", "entity_attack", "fire_tick", "projectile", "suffocation", "fall", "fatal", "starve", "fire", "drowning", "block_explosion", "entity_explosion", "void", "suicide", "magic", "wither", "charging", "anvil", "thorns", "falling_block", "piston", "magma", "fireworks", "temperature", "all"
+        "override", "contact", "none", "lava", "entity_attack", "fire_tick", "projectile", "suffocation", "fall", "fatal", "starve", "fire", "drowning", "block_explosion", "entity_explosion", "void", "suicide", "magic", "wither", "charging", "anvil", "thorns", "falling_block", "piston", "magma", "fireworks", "temperature", "lightning", "all"
     ],
     "potion_number_id": [
         "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "34", "35", "36", "37", "38", "39", "40", "41"


### PR DESCRIPTION
## Description
I added lightning to `damage_type`.

## Motivation and Context
The turtle entity uses this, so I suppose this a valid cause that can be used.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes require updating to the plugin documentation.
