### PR TITLE
Update release workflow to include asar file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
                   files: |
                       build/nsis-web/*.exe
                       build/nsis-web/*.nsis.7z
+                      build/win-unpacked/resources/app.asar
                       build/*.snap
                       build/*.AppImage
                       build/*.dmg


### PR DESCRIPTION
Uploads the Windows generated .asar file to the release (just to prevent duplicate asar files getting uploaded)