### PR TITLE
Missing autocompletions

### DIFF
--- a/static/auto_completions/entity/components.json
+++ b/static/auto_completions/entity/components.json
@@ -610,7 +610,7 @@
         "avoid_sun": "$general.boolean",
         "avoid_water": "$general.boolean",
         "avoid_damage_blocks": "$general.boolean",
-		"can_break_doors": "$general.boolean",
+        "can_break_doors": "$general.boolean",
         "can_open_doors": "$general.boolean",
         "can_pass_doors": "$general.boolean",
         "can_path_over_water": "$general.boolean",

--- a/static/auto_completions/entity/components.json
+++ b/static/auto_completions/entity/components.json
@@ -610,6 +610,7 @@
         "avoid_sun": "$general.boolean",
         "avoid_water": "$general.boolean",
         "avoid_damage_blocks": "$general.boolean",
+		"can_break_doors": "$general.boolean",
         "can_open_doors": "$general.boolean",
         "can_pass_doors": "$general.boolean",
         "can_path_over_water": "$general.boolean",

--- a/static/auto_completions/entity/general.json
+++ b/static/auto_completions/entity/general.json
@@ -6,8 +6,8 @@
         "effect": "$general.effect_name",
         "duration": "$general.number",
         "amplifier": "$general.number",
-        "visible": "$general.number_boolean",
-        "ambient": "$general.number_boolean",
+        "visible": "$general.boolean",
+        "ambient": "$general.boolean",
         "display_on_screen_animation": "$general.boolean"
     },
     "component_group_name": {

--- a/static/auto_completions/general.json
+++ b/static/auto_completions/general.json
@@ -106,7 +106,7 @@
         "@import.value.file_identifier": "($dynamic.setting.project_prefix + $dynamic.current_file_name)"
     },
     "inventory_type": [
-        "minecart_chest", "horse", "minecart_hopper", "container"
+        "minecart_chest", "horse", "minecart_hopper", "container", "inventory", "hopper"
     ],
     "damage_type": [
         "override", "contact", "none", "lava", "entity_attack", "fire_tick", "projectile", "suffocation", "fall", "fatal", "starve", "fire", "drowning", "block_explosion", "entity_explosion", "void", "suicide", "magic", "wither", "charging", "anvil", "thorns", "falling_block", "piston", "magma", "fireworks", "temperature", "lightning", "all"


### PR DESCRIPTION
## Description
- Added `can_break_doors` autocompletion for navigation components
- Added `inventory` and `hopper` to inventory types
- Changed autocompletion values for `visible` and `ambient` to a general boolean

## Motivation and Context
Added autocompletions that can be used. Also changed the autocompletion values for `visible` and `ambient` inside the effect component. In my opinion it easier to suggest true/false to users instead of 0/1. If not, I will revert this.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My changes require updating to the plugin documentation.
