### PR TITLE
Publish workflow updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,24 +11,15 @@ jobs:
                 platform: [windows-latest, ubuntu-latest, macos-latest]
         runs-on: ${{ matrix.platform }}
         steps:
-            - uses: actions/checkout@v1
+            - name: Checkout
+              uses: actions/checkout@v1
             - name: Setup Node.js
               uses: actions/setup-node@v1
               with:
                   node-version: 12
-            - name: npm install and build
+            - name: Build and release
               run: |
                   npm install
-                  npm run build
-            - name: Upload to release
-              uses: softprops/action-gh-release@v1
-              with:
-                  files: |
-                      build/nsis-web/*.exe
-                      build/nsis-web/*.nsis.7z
-                      build/win-unpacked/resources/app.asar
-                      build/*.snap
-                      build/*.AppImage
-                      build/*.dmg
+                  npm run release
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2445,8 +2445,7 @@
     "@types/node": {
       "version": "12.12.34",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.34.tgz",
-      "integrity": "sha512-BneGN0J9ke24lBRn44hVHNeDlrXRYF+VRp0HbSUNnEZahXGAysHZIqnf/hER6aabdBgzM4YOV4jrR8gj4Zfi0g==",
-      "dev": true
+      "integrity": "sha512-BneGN0J9ke24lBRn44hVHNeDlrXRYF+VRp0HbSUNnEZahXGAysHZIqnf/hER6aabdBgzM4YOV4jrR8gj4Zfi0g=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -2459,6 +2458,14 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
       "dev": true
+    },
+    "@types/semver": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.2.0.tgz",
+      "integrity": "sha512-TbB0A8ACUWZt3Y6bQPstW9QNbhNeebdgLX4T/ZfkrswAfUzRiXrgd9seol+X379Wa589Pu4UEx9Uok0D4RjRCQ==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -3219,6 +3226,11 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atob": {
       "version": "2.1.2",
@@ -6653,6 +6665,79 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.398.tgz",
       "integrity": "sha512-BJjxuWLKFbM5axH3vES7HKMQgAknq9PZHBkMK/rEXUQG9i1Iw5R+6hGkm6GtsQSANjSUrh/a6m32nzCNDNo/+w==",
       "dev": true
+    },
+    "electron-updater": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.3.1.tgz",
+      "integrity": "sha512-UDC5AHCgeiHJYDYWZG/rsl1vdAFKqI/Lm7whN57LKAk8EfhTewhcEHzheRcncLgikMcQL8gFo1KeX51tf5a5Wg==",
+      "requires": {
+        "@types/semver": "^7.1.0",
+        "builder-util-runtime": "8.7.0",
+        "fs-extra": "^9.0.0",
+        "js-yaml": "^3.13.1",
+        "lazy-val": "^1.0.4",
+        "lodash.isequal": "^4.5.0",
+        "semver": "^7.1.3"
+      },
+      "dependencies": {
+        "builder-util-runtime": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.0.tgz",
+          "integrity": "sha512-G1AqqVM2vYTrSFR982c1NNzwXKrGLQjVjaZaWQdn4O6Z3YKjdMDofw88aD9jpyK9ZXkrCxR0tI3Qe9wNbyTlXg==",
+          "requires": {
+            "debug": "^4.1.1",
+            "sax": "^1.2.4"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-extra": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+        }
+      }
     },
     "elliptic": {
       "version": "6.5.2",
@@ -11404,8 +11489,7 @@
     "lazy-val": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.4.tgz",
-      "integrity": "sha512-u93kb2fPbIrfzBuLjZE+w+fJbUUMhNDXxNmMfaqNgpfQf1CO5ZSe2LfsnBqVAk7i/2NF48OSoRj+Xe2VT+lE8Q==",
-      "dev": true
+      "integrity": "sha512-u93kb2fPbIrfzBuLjZE+w+fJbUUMhNDXxNmMfaqNgpfQf1CO5ZSe2LfsnBqVAk7i/2NF48OSoRj+Xe2VT+lE8Q=="
     },
     "lazystream": {
       "version": "1.0.0",
@@ -11626,6 +11710,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
@@ -14510,8 +14599,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
       "version": "3.1.11",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,11 @@
       ]
     },
     "linux": {
-      "publish": ["github"],
+      "publish": [{
+        "provider": "github",
+        "owner": "bridge-core",
+        "releaseType": "release"
+      }],
       "icon": "build/icons"
     }
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/electron/main.js",
   "scripts": {
     "build": "node --max_old_space_size=8192 .electron-vue/build.js && electron-builder --publish=never",
+    "release": "node --max_old_space_size=8192 .electron-vue/build.js && electron-builder",
     "build:dir": "node .electron-vue/build.js && electron-builder --dir",
     "build:clean": "cross-env BUILD_TARGET=clean node .electron-vue/build.js",
     "dev": "node .electron-vue/dev-runner.js",
@@ -26,6 +27,11 @@
     "files": [
       "dist/electron/**/*"
     ],
+    "publish": [{
+      "provider": "github",
+      "owner": "bridge-core",
+      "releaseType": "release"
+    }],
     "dmg": {
       "contents": [
         {
@@ -57,6 +63,7 @@
       ]
     },
     "linux": {
+      "publish": ["github"],
       "icon": "build/icons"
     }
   },
@@ -71,6 +78,7 @@
     "deepmerge": "^4.2.2",
     "discord-rich-presence": "0.0.8",
     "electron-dl": "^3.0.0",
+    "electron-updater": "^4.3.1",
     "font-list": "^1.2.8",
     "fs-extra": "^8.1.0",
     "image-size": "^0.8.3",


### PR DESCRIPTION
## Description
This PR changes the way releases are performed by the CI. It essentially does the same thing as before, however it generates the required `latest.yml` file that we need for auto updating.

**This means the asar file is no longer uploaded** - however we shouldn't need it if we are going to use `electron-updater` for auto updating.

## Motivation and Context
As mentioned above, this is required to implement the auto update feature.

## Testing
I have been actively testing all changes in a [fork](https://github.com/montudor-tests/bridge/releases/tag/v1.7.3), and it has been generating the required files.

## Tasks
- [x] Setup the publish info
- [x] Windows support
- [x] Mac support
- [x] Linux support
