### PR TITLE
Only display directories in linking RP window

### DIFF
--- a/app/renderer/windows/LinkRPWindow.ts
+++ b/app/renderer/windows/LinkRPWindow.ts
@@ -7,7 +7,13 @@ export default class LinkRPWindow extends ContentWindow {
 	private selected_rp: string
 
 	constructor(bp_name: string) {
-		const PROJECTS = fs.readdirSync(RP_BASE_PATH)
+		const PROJECTS = (
+			fs.readdirSync(RP_BASE_PATH, {
+				withFileTypes: true,
+			})
+		)
+			.filter(dirent => dirent.isDirectory())
+			.map(dirent => dirent.name)
 
 		super({
 			display_name: 'Link Project To Resource Pack',


### PR DESCRIPTION
## Description
Partially relating to my old #118, files are displaying on the linking RP modal which are not folders.

## Motivation and Context
Simply a copy from the modified fix to #118 from [load.ts](https://github.com/bridge-core/bridge./blob/master/app/renderer/src/UI/ProjectScreen/load.ts#L12-L18). Since I could not find an exported method from a quick search that does this, I inlined it.
If it's easier to close this PR and do this in another commit, feel free to. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes require updating to the plugin documentation.
