### PR TITLE
Disallow filenames beginning with "../../../"

### DIFF
--- a/app/renderer/windows/CreateFile.js
+++ b/app/renderer/windows/CreateFile.js
@@ -2,34 +2,21 @@ import FileSystem from '../src/FileSystem'
 import ContentWindow from '../src/UI/Windows/Common/Content'
 import Store from '../store/index'
 import FileType from '../src/editor/FileType'
-import {
-	run
-} from '../src/editor/ScriptRunner/run'
+import { run } from '../src/editor/ScriptRunner/run'
 
-import {
-	RP_BASE_PATH,
-	BASE_PATH
-} from '../src/constants'
+import { RP_BASE_PATH, BASE_PATH } from '../src/constants'
 import uuidv4 from 'uuid/v4'
-import {
-	walkSync
-} from '../src/autoCompletions/Dynamic'
-import {
-	join
-} from 'path'
-import {
-	promises as fs
-} from 'fs'
+import { walkSync } from '../src/autoCompletions/Dynamic'
+import { join } from 'path'
+import { promises as fs } from 'fs'
 
 class FileContent {
 	constructor(
 		name,
 		ext = 'json',
 		parent,
-		expand_path = '', {
-			add_location,
-			...add_content
-		} = {},
+		expand_path = '',
+		{ add_location, ...add_content } = {},
 		use_rp_path,
 		is_custom_syntax = false,
 		is_experimental = false
@@ -44,59 +31,57 @@ class FileContent {
 			type: 'horizontal',
 			center: true,
 			key: uuidv4(),
-			content: [{
-				type: 'input',
-				text: 'Name',
-				input: this.curr_input,
-				has_focus: true,
-				color: 'primary',
-				key: uuidv4(),
-				action: {
-					enter: () => {
-						if (this.curr_input !== '') this.parent.createFile()
-					},
-					default: val => {
-						this.curr_input = val
+			content: [
+				{
+					type: 'input',
+					text: 'Name',
+					input: this.curr_input,
+					has_focus: true,
+					color: 'primary',
+					key: uuidv4(),
+					action: {
+						enter: () => {
+							if (this.curr_input !== '') this.parent.createFile()
+						},
+						default: val => {
+							this.curr_input = val
 
-						if (
-							val === '' ||
-							/\.\.(\\|\/)/g.test(val)
-						) {
-							if (!this.parent.actions[1].is_disabled) {
-								this.input.content[0].color = 'error'
+							if (val === '' || /\.\.(\\|\/)/g.test(val)) {
+								if (!this.parent.actions[1].is_disabled) {
+									this.input.content[0].color = 'error'
+									this.input.content[0].key = uuidv4()
+									this.input.content[0].input = this.curr_input
+									this.parent.actions[1].is_disabled = true
+
+									// this.path_info.text = "Invalid file name!\n\n"
+									// this.path_info.color = "error";
+
+									this.parent.update({
+										content: this.content,
+										actions: this.parent.actions,
+									})
+								}
+							} else if (this.parent.actions[1].is_disabled) {
+								this.input.content[0].color = 'primary'
 								this.input.content[0].key = uuidv4()
 								this.input.content[0].input = this.curr_input
-								this.parent.actions[1].is_disabled = true
+								this.parent.actions[1].is_disabled = false
 
-								// this.path_info.text = "Invalid file name!\n\n"
-								// this.path_info.color = "error";
+								// this.path_info.text = this.getPath(val) + "\n\n";
+								// this.path_info.color = "grey";
 
 								this.parent.update({
 									content: this.content,
 									actions: this.parent.actions,
 								})
 							}
-						} else if (this.parent.actions[1].is_disabled) {
-							this.input.content[0].color = 'primary'
-							this.input.content[0].key = uuidv4()
-							this.input.content[0].input = this.curr_input
-							this.parent.actions[1].is_disabled = false
-
-							// this.path_info.text = this.getPath(val) + "\n\n";
-							// this.path_info.color = "grey";
-
-							this.parent.update({
-								content: this.content,
-								actions: this.parent.actions,
-							})
-						}
+						},
 					},
 				},
-			},
-			{
-				text: `.${ext}`,
-				color: 'grey',
-			},
+				{
+					text: `.${ext}`,
+					color: 'grey',
+				},
 			],
 		}
 		this.path_info = () => {
@@ -106,71 +91,85 @@ class FileContent {
 			}
 		}
 
-		this.content = [{
-			text: '\n',
-		},
-		{
-			type: 'container',
-			display: 'inline-block',
-			height: '32px',
-			content: [
-				is_experimental ? [{
-					type: 'icon',
-					text: 'mdi-test-tube',
-					color: 'purple',
-					tooltip: 'Experimental Gameplay',
-				},] : [],
-				is_custom_syntax ? [{
-					type: 'icon',
-					text: 'mdi-code-braces',
-					color: 'purple',
-					tooltip: 'Custom Syntax',
-				},] : [],
-				{
-					type: 'big-header',
-					text: name,
-				},
-			].flat(),
-		},
-		{
-			type: 'divider',
-		},
-		{
-			text: '\n',
-		},
-		this.input,
-		this.path_info,
+		this.content = [
+			{
+				text: '\n',
+			},
+			{
+				type: 'container',
+				display: 'inline-block',
+				height: '32px',
+				content: [
+					is_experimental
+						? [
+								{
+									type: 'icon',
+									text: 'mdi-test-tube',
+									color: 'purple',
+									tooltip: 'Experimental Gameplay',
+								},
+						  ]
+						: [],
+					is_custom_syntax
+						? [
+								{
+									type: 'icon',
+									text: 'mdi-code-braces',
+									color: 'purple',
+									tooltip: 'Custom Syntax',
+								},
+						  ]
+						: [],
+					{
+						type: 'big-header',
+						text: name,
+					},
+				].flat(),
+			},
+			{
+				type: 'divider',
+			},
+			{
+				text: '\n',
+			},
+			this.input,
+			this.path_info,
 		]
 
 		if (add_location === undefined) add_location = []
 		if (add_content !== undefined && Object.keys(add_content).length !== 0)
-			this.add({
-				...add_content,
-				action: parameter => {
-					if (
-						add_content.action !== undefined &&
-						add_content.action.type === 'change_path'
-					) {
-						this.expand_path = run(add_content.action.to, {
-							parameter,
-						}, {
-							executionContext: "inline"
-						})
-						this.path_info.text = this.getPath(
-							undefined,
-							undefined
-						)
-						this.parent.update({
-							content: this.content,
-						})
-					} else if (add_content.action !== undefined) {
-						throw new Error(
-							'Unknown add_content.action type: ' +
-							add_content.action.type
-						)
-					}
+			this.add(
+				{
+					...add_content,
+					action: parameter => {
+						if (
+							add_content.action !== undefined &&
+							add_content.action.type === 'change_path'
+						) {
+							this.expand_path = run(
+								add_content.action.to,
+								{
+									parameter,
+								},
+								{
+									executionContext: 'inline',
+								}
+							)
+							this.path_info.text = this.getPath(
+								undefined,
+								undefined
+							)
+							this.parent.update({
+								content: this.content,
+							})
+						} else if (add_content.action !== undefined) {
+							throw new Error(
+								'Unknown add_content.action type: ' +
+									add_content.action.type
+							)
+						}
+					},
 				},
-			},
 				...add_location
 			)
 	}
@@ -180,7 +179,7 @@ class FileContent {
 			this.use_rp_path
 				? Store.state.Explorer.project.resource_pack
 				: Store.state.Explorer.project.explorer
-			}/${expand}${val}.${ext}`
+		}/${expand}${val}.${ext}`
 	}
 
 	getFullPath(val, ext, expand) {
@@ -210,18 +209,10 @@ export default class CreateFileWindow extends ContentWindow {
 		)
 			FILE_DATA = FileType.getFileCreators()
 				.filter(f => (show_rp ? f.rp_definition : !f.rp_definition))
-				.sort(({
-					title: t1
-				}, {
-					title: t2
-				}) => t1.localeCompare(t2))
+				.sort(({ title: t1 }, { title: t2 }) => t1.localeCompare(t2))
 		else
 			FILE_DATA = FileType.getFileCreators().sort(
-				({
-					title: t1
-				}, {
-					title: t2
-				}) => t1.localeCompare(t2)
+				({ title: t1 }, { title: t2 }) => t1.localeCompare(t2)
 			)
 
 		super({
@@ -230,11 +221,7 @@ export default class CreateFileWindow extends ContentWindow {
 				is_visible: false,
 				is_persistent: false,
 			},
-			sidebar: FILE_DATA.map(({
-				icon,
-				title,
-				rp_definition
-			}, index) => {
+			sidebar: FILE_DATA.map(({ icon, title, rp_definition }, index) => {
 				return {
 					icon,
 					title,
@@ -257,17 +244,18 @@ export default class CreateFileWindow extends ContentWindow {
 			)
 			this.close()
 		}
-		this.actions = [{
-			type: 'space',
-		},
-		{
-			type: 'button',
-			text: 'Create!',
-			color: 'primary',
-			is_rounded: false,
-			is_disabled: false,
-			action: this.createFile,
-		},
+		this.actions = [
+			{
+				type: 'space',
+			},
+			{
+				type: 'button',
+				text: 'Create!',
+				color: 'primary',
+				is_rounded: false,
+				is_disabled: false,
+				action: this.createFile,
+			},
 		]
 		this.win_def.actions = this.actions
 		this.contents = FILE_DATA.map(
@@ -292,10 +280,7 @@ export default class CreateFileWindow extends ContentWindow {
 				)
 		)
 		//Templates
-		this.templates = FILE_DATA.map(({
-			templates,
-			rp_definition
-		}) => {
+		this.templates = FILE_DATA.map(({ templates, rp_definition }) => {
 			return {
 				...templates,
 				rp_definition,
@@ -316,9 +301,11 @@ export default class CreateFileWindow extends ContentWindow {
 		this.win_def.sidebar[id].opacity = 1
 		this.win_def.sidebar[id].is_selected = true
 		this.win_def.options.is_visible = true
-		this.win_def.content = this.contents[id].get() || [{
-			text: 'Nothing to show yet',
-		},]
+		this.win_def.content = this.contents[id].get() || [
+			{
+				text: 'Nothing to show yet',
+			},
+		]
 
 		if (this.templates[id] && !this.win_def.content.added_select)
 			await this.compileTemplate(this.templates[id])
@@ -326,11 +313,7 @@ export default class CreateFileWindow extends ContentWindow {
 	}
 
 	async compileTemplate(templ) {
-		const {
-			$default_pack,
-			rp_definition,
-			...templates
-		} = templ
+		const { $default_pack, rp_definition, ...templates } = templ
 		if ($default_pack !== undefined) {
 			let arr
 			let p = join(__static, 'vanilla', $default_pack.path)
@@ -347,29 +330,33 @@ export default class CreateFileWindow extends ContentWindow {
 		this.win_def.content.added_select = true
 		if (options.length === 1) return
 
-		this.win_def.content.push({
-			type: 'header',
-			text: 'Templates',
-		}, {
-			type: 'divider',
-		}, {
-			type: options.length <= 6 ? 'select' : 'autocomplete',
-			is_box: true,
-			options,
-			text: 'Select template',
-			action: async val => {
-				if (templates[val] === undefined) this.chosen_template = ''
-				else if (typeof templates[val] === 'function')
-					this.chosen_template = await templates[val]()
-				else if (typeof templates[val] === 'string')
-					this.chosen_template = templates[val]
-				else
-					this.chosen_template = JSON.stringify(
-						templates[val],
-						null,
-						'\t'
-					)
+		this.win_def.content.push(
+			{
+				type: 'header',
+				text: 'Templates',
 			},
-		})
+			{
+				type: 'divider',
+			},
+			{
+				type: options.length <= 6 ? 'select' : 'autocomplete',
+				is_box: true,
+				options,
+				text: 'Select template',
+				action: async val => {
+					if (templates[val] === undefined) this.chosen_template = ''
+					else if (typeof templates[val] === 'function')
+						this.chosen_template = await templates[val]()
+					else if (typeof templates[val] === 'string')
+						this.chosen_template = templates[val]
+					else
+						this.chosen_template = JSON.stringify(
+							templates[val],
+							null,
+							'\t'
+						)
+				},
+			}
+		)
 	}
 }

--- a/app/renderer/windows/CreateFile.js
+++ b/app/renderer/windows/CreateFile.js
@@ -59,21 +59,23 @@ class FileContent {
 							this.curr_input = val
 
 							if (
-								val === '' &&
-								!this.parent.actions[1].is_disabled
+								val === '' ||
+								val.indexOf('../../../') == 0
 							) {
-								this.input.content[0].color = 'error'
-								this.input.content[0].key = uuidv4()
-								this.input.content[0].input = this.curr_input
-								this.parent.actions[1].is_disabled = true
+								if (!this.parent.actions[1].is_disabled) {
+									this.input.content[0].color = 'error'
+									this.input.content[0].key = uuidv4()
+									this.input.content[0].input = this.curr_input
+									this.parent.actions[1].is_disabled = true
 
-								// this.path_info.text = "Invalid file name!\n\n"
-								// this.path_info.color = "error";
+									// this.path_info.text = "Invalid file name!\n\n"
+									// this.path_info.color = "error";
 
-								this.parent.update({
-									content: this.content,
-									actions: this.parent.actions,
-								})
+									this.parent.update({
+										content: this.content,
+										actions: this.parent.actions,
+									})
+								}
 							} else if (this.parent.actions[1].is_disabled) {
 								this.input.content[0].color = 'primary'
 								this.input.content[0].key = uuidv4()
@@ -246,6 +248,7 @@ export default class CreateFileWindow extends ContentWindow {
 		})
 
 		this.createFile = () => {
+			if (this.current_content.getFullPath.indexOf('../../../') == 0) return // Silently stop. Shouldn't ever happen
 			FileSystem.save(
 				this.current_content.getFullPath(),
 				this.chosen_template,

--- a/app/renderer/windows/CreateFile.js
+++ b/app/renderer/windows/CreateFile.js
@@ -45,58 +45,58 @@ class FileContent {
 			center: true,
 			key: uuidv4(),
 			content: [{
-					type: 'input',
-					text: 'Name',
-					input: this.curr_input,
-					has_focus: true,
-					color: 'primary',
-					key: uuidv4(),
-					action: {
-						enter: () => {
-							if (this.curr_input !== '') this.parent.createFile()
-						},
-						default: val => {
-							this.curr_input = val
+				type: 'input',
+				text: 'Name',
+				input: this.curr_input,
+				has_focus: true,
+				color: 'primary',
+				key: uuidv4(),
+				action: {
+					enter: () => {
+						if (this.curr_input !== '') this.parent.createFile()
+					},
+					default: val => {
+						this.curr_input = val
 
-							if (
-								val === '' ||
-								val.indexOf('../../../') == 0
-							) {
-								if (!this.parent.actions[1].is_disabled) {
-									this.input.content[0].color = 'error'
-									this.input.content[0].key = uuidv4()
-									this.input.content[0].input = this.curr_input
-									this.parent.actions[1].is_disabled = true
-
-									// this.path_info.text = "Invalid file name!\n\n"
-									// this.path_info.color = "error";
-
-									this.parent.update({
-										content: this.content,
-										actions: this.parent.actions,
-									})
-								}
-							} else if (this.parent.actions[1].is_disabled) {
-								this.input.content[0].color = 'primary'
+						if (
+							val === '' ||
+							/\.\.(\\|\/)/g.test(val)
+						) {
+							if (!this.parent.actions[1].is_disabled) {
+								this.input.content[0].color = 'error'
 								this.input.content[0].key = uuidv4()
 								this.input.content[0].input = this.curr_input
-								this.parent.actions[1].is_disabled = false
+								this.parent.actions[1].is_disabled = true
 
-								// this.path_info.text = this.getPath(val) + "\n\n";
-								// this.path_info.color = "grey";
+								// this.path_info.text = "Invalid file name!\n\n"
+								// this.path_info.color = "error";
 
 								this.parent.update({
 									content: this.content,
 									actions: this.parent.actions,
 								})
 							}
-						},
+						} else if (this.parent.actions[1].is_disabled) {
+							this.input.content[0].color = 'primary'
+							this.input.content[0].key = uuidv4()
+							this.input.content[0].input = this.curr_input
+							this.parent.actions[1].is_disabled = false
+
+							// this.path_info.text = this.getPath(val) + "\n\n";
+							// this.path_info.color = "grey";
+
+							this.parent.update({
+								content: this.content,
+								actions: this.parent.actions,
+							})
+						}
 					},
 				},
-				{
-					text: `.${ext}`,
-					color: 'grey',
-				},
+			},
+			{
+				text: `.${ext}`,
+				color: 'grey',
+			},
 			],
 		}
 		this.path_info = () => {
@@ -107,70 +107,70 @@ class FileContent {
 		}
 
 		this.content = [{
-				text: '\n',
-			},
-			{
-				type: 'container',
-				display: 'inline-block',
-				height: '32px',
-				content: [
-					is_experimental ? [{
-						type: 'icon',
-						text: 'mdi-test-tube',
-						color: 'purple',
-						tooltip: 'Experimental Gameplay',
-					}, ] : [],
-					is_custom_syntax ? [{
-						type: 'icon',
-						text: 'mdi-code-braces',
-						color: 'purple',
-						tooltip: 'Custom Syntax',
-					}, ] : [],
-					{
-						type: 'big-header',
-						text: name,
-					},
-				].flat(),
-			},
-			{
-				type: 'divider',
-			},
-			{
-				text: '\n',
-			},
-			this.input,
-			this.path_info,
+			text: '\n',
+		},
+		{
+			type: 'container',
+			display: 'inline-block',
+			height: '32px',
+			content: [
+				is_experimental ? [{
+					type: 'icon',
+					text: 'mdi-test-tube',
+					color: 'purple',
+					tooltip: 'Experimental Gameplay',
+				},] : [],
+				is_custom_syntax ? [{
+					type: 'icon',
+					text: 'mdi-code-braces',
+					color: 'purple',
+					tooltip: 'Custom Syntax',
+				},] : [],
+				{
+					type: 'big-header',
+					text: name,
+				},
+			].flat(),
+		},
+		{
+			type: 'divider',
+		},
+		{
+			text: '\n',
+		},
+		this.input,
+		this.path_info,
 		]
 
 		if (add_location === undefined) add_location = []
 		if (add_content !== undefined && Object.keys(add_content).length !== 0)
 			this.add({
-					...add_content,
-					action: parameter => {
-						if (
-							add_content.action !== undefined &&
-							add_content.action.type === 'change_path'
-						) {
-							this.expand_path = run(add_content.action.to, {
-								parameter,
-							}, {
-								executionContext: "inline"
-							})
-							this.path_info.text = this.getPath(
-								undefined,
-								undefined
-							)
-							this.parent.update({
-								content: this.content,
-							})
-						} else if (add_content.action !== undefined) {
-							throw new Error(
-								'Unknown add_content.action type: ' +
-								add_content.action.type
-							)
-						}
-					},
+				...add_content,
+				action: parameter => {
+					if (
+						add_content.action !== undefined &&
+						add_content.action.type === 'change_path'
+					) {
+						this.expand_path = run(add_content.action.to, {
+							parameter,
+						}, {
+							executionContext: "inline"
+						})
+						this.path_info.text = this.getPath(
+							undefined,
+							undefined
+						)
+						this.parent.update({
+							content: this.content,
+						})
+					} else if (add_content.action !== undefined) {
+						throw new Error(
+							'Unknown add_content.action type: ' +
+							add_content.action.type
+						)
+					}
 				},
+			},
 				...add_location
 			)
 	}
@@ -180,7 +180,7 @@ class FileContent {
 			this.use_rp_path
 				? Store.state.Explorer.project.resource_pack
 				: Store.state.Explorer.project.explorer
-		}/${expand}${val}.${ext}`
+			}/${expand}${val}.${ext}`
 	}
 
 	getFullPath(val, ext, expand) {
@@ -209,12 +209,12 @@ export default class CreateFileWindow extends ContentWindow {
 			Store.state.Explorer.project.resource_pack === undefined
 		)
 			FILE_DATA = FileType.getFileCreators()
-			.filter(f => (show_rp ? f.rp_definition : !f.rp_definition))
-			.sort(({
-				title: t1
-			}, {
-				title: t2
-			}) => t1.localeCompare(t2))
+				.filter(f => (show_rp ? f.rp_definition : !f.rp_definition))
+				.sort(({
+					title: t1
+				}, {
+					title: t2
+				}) => t1.localeCompare(t2))
 		else
 			FILE_DATA = FileType.getFileCreators().sort(
 				({
@@ -248,7 +248,7 @@ export default class CreateFileWindow extends ContentWindow {
 		})
 
 		this.createFile = () => {
-			if (this.current_content.getFullPath.indexOf('../../../') == 0) return // Silently stop. Shouldn't ever happen
+			if (/\.\.(\\|\/)/g.test(this.current_content.getFullPath.indexOf)) return // Silently stop. Shouldn't ever happen
 			FileSystem.save(
 				this.current_content.getFullPath(),
 				this.chosen_template,
@@ -258,16 +258,16 @@ export default class CreateFileWindow extends ContentWindow {
 			this.close()
 		}
 		this.actions = [{
-				type: 'space',
-			},
-			{
-				type: 'button',
-				text: 'Create!',
-				color: 'primary',
-				is_rounded: false,
-				is_disabled: false,
-				action: this.createFile,
-			},
+			type: 'space',
+		},
+		{
+			type: 'button',
+			text: 'Create!',
+			color: 'primary',
+			is_rounded: false,
+			is_disabled: false,
+			action: this.createFile,
+		},
 		]
 		this.win_def.actions = this.actions
 		this.contents = FILE_DATA.map(
@@ -280,16 +280,16 @@ export default class CreateFileWindow extends ContentWindow {
 				is_custom_syntax,
 				is_experimental,
 			}) =>
-			new FileContent(
-				title,
-				extension,
-				this,
-				path,
-				add_content,
-				rp_definition,
-				is_custom_syntax,
-				is_experimental
-			)
+				new FileContent(
+					title,
+					extension,
+					this,
+					path,
+					add_content,
+					rp_definition,
+					is_custom_syntax,
+					is_experimental
+				)
 		)
 		//Templates
 		this.templates = FILE_DATA.map(({
@@ -318,7 +318,7 @@ export default class CreateFileWindow extends ContentWindow {
 		this.win_def.options.is_visible = true
 		this.win_def.content = this.contents[id].get() || [{
 			text: 'Nothing to show yet',
-		}, ]
+		},]
 
 		if (this.templates[id] && !this.win_def.content.added_select)
 			await this.compileTemplate(this.templates[id])


### PR DESCRIPTION
Added a check when a file is created using the "New File" button for paths beginning in "../../../" to help prevent escaping the MC workspace.  
<!--- Provide a general summary of your changes in the Title above -->

## Description
Simply check if the file name begins in "../../../" and don't create the file if it does.  

## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses issue #92

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes require updating to the plugin documentation.
