### PR TITLE
Add hold_on_last_frame option

### DIFF
--- a/static/auto_completions/animation/general.json
+++ b/static/auto_completions/animation/general.json
@@ -1,3 +1,15 @@
 {
-    "events": "$dynamic.entity.@events"
+    "events": "$dynamic.entity.@events",
+    "loop_type": {
+        "@meta": {
+            "validate": {
+                "confirm": "Bridge.Node.data !== 'true' && Bridge.Node.data !== 'false' && Bridge.Node.data !== 'hold_on_last_frame'",
+                "then": {
+                    "show": true,
+                    "message": "Invalid data type: Expected boolean or hold_on_last_frame string"
+                }
+            }
+        },
+        "@import.value": ["true", "false", "hold_on_last_frame"]
+    }
 }

--- a/static/auto_completions/animation/rp_main.json
+++ b/static/auto_completions/animation/rp_main.json
@@ -7,7 +7,7 @@
             "animation_length": "$general.number",
             "blend_weight": "$general.decimal",
             "override_previous_animation": "$general.boolean",
-            "loop": "$general.boolean",
+            "loop": "$animation.general.loop_type",
             "bones": {
                 "$placeholder": {
                     "rotation": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the `hold_on_last_frame` option as a string value for `loop` to the resource pack animation auto completion

## Screenshots (if appropriate):
From the Nether Update (1.16) bedrock changelog:
![image](https://user-images.githubusercontent.com/7486865/85619304-5fe33f00-b662-11ea-95a8-26cf2dfa5553.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have tested my changes and confirmed that they are working
