### PR TITLE
Don't suggest adding client scripts for resource pack manifest

### DIFF
--- a/app/renderer/src/UI/ContextMenu/File.ts
+++ b/app/renderer/src/UI/ContextMenu/File.ts
@@ -132,25 +132,27 @@ export const FILE_CONTEXT_MENU = async (
 	 * QUICK ACTION TO TOGGLE CLIENT SCRIPTS
 	 */
 	if (fileName === 'manifest.json') {
-		let manifest: Manifest = await readJSON(file_path).catch(console.error)
-		if (Manifest.hasClientData(manifest)) {
-			DEFAULT_MENU.push({
-				title: 'Remove Client Scripts',
-				icon: 'mdi-minus',
-				action: () => {
-					Manifest.removeClientData(manifest)
-					writeJSON(file_path, manifest)
-				},
-			})
-		} else {
-			DEFAULT_MENU.push({
-				title: 'Add Client Scripts',
-				icon: 'mdi-plus',
-				action: () => {
-					Manifest.addClientData(manifest)
-					writeJSON(file_path, manifest)
-				},
-			})
+		if (Manifest.getPackFolder(file_path) === 'development_behavior_packs') {
+			let manifest: Manifest = await readJSON(file_path).catch(console.error)
+			if (Manifest.hasClientData(manifest)) {
+				DEFAULT_MENU.push({
+					title: 'Remove Client Scripts',
+					icon: 'mdi-minus',
+					action: () => {
+						Manifest.removeClientData(manifest)
+						writeJSON(file_path, manifest)
+					},
+				})
+			} else {
+				DEFAULT_MENU.push({
+					title: 'Add Client Scripts',
+					icon: 'mdi-plus',
+					action: () => {
+						Manifest.addClientData(manifest)
+						writeJSON(file_path, manifest)
+					},
+				})
+			}
 		}
 	}
 

--- a/app/renderer/src/files/Manifest.ts
+++ b/app/renderer/src/files/Manifest.ts
@@ -3,6 +3,7 @@
  */
 import uuidv4 from 'uuid/v4'
 import ProjectConfig from '../Project/Config'
+import path from 'path'
 
 interface Module {
 	type: string
@@ -96,6 +97,11 @@ export default class Manifest {
 			if (type === 'client_data') return true
 		}
 		return false
+	}
+
+	static getPackFolder(file_path: string) {
+		let folders = path.dirname(file_path).split(path.sep)
+		return folders[folders.length - 2]
 	}
 
 	get uuid() {


### PR DESCRIPTION
## Description
Removed the option to add client_data to resource pack manifest file

## Motivation and Context
client_data inside the resource pack manifest is not needed for scripts

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code follows the code style of this project.
Maybe there is a better solution?
- [x] I have tested my changes and confirmed that they are working
