### PR TITLE
v1.7.15

### DIFF
--- a/app/renderer/src/UI/Sidebar/Content/Explorer.vue
+++ b/app/renderer/src/UI/Sidebar/Content/Explorer.vue
@@ -153,7 +153,7 @@ export default {
 			projectIcon: undefined,
 		}
 	},
-	created() {
+	mounted() {
 		this.projectIcon = this.loadProjectIcon()
 		this.$root.$on('refreshExplorer', () =>
 			EventBus.trigger('bridge:refreshExplorer')

--- a/app/renderer/src/UI/Sidebar/Content/plugin/Card.vue
+++ b/app/renderer/src/UI/Sidebar/Content/plugin/Card.vue
@@ -79,6 +79,7 @@ import { readJSON, writeJSON } from '../../../../Utilities/JsonFS'
 import path from 'path'
 import { CURRENT } from '../../../../constants'
 import LoadingWindow from '../../../../../windows/LoadingWindow'
+import { BridgeCore } from '../../../../bridgeCore/main'
 
 export default {
 	name: 'plugin-card',
@@ -129,6 +130,7 @@ export default {
 					this.plugin.pluginFolder,
 					plugins
 				)
+			else BridgeCore.activate()
 
 			lw.close()
 		},
@@ -151,6 +153,7 @@ export default {
 			//This ensures that we're not trying to unload the built-in bridge. Core plugin
 			if (this.plugin.pluginPath)
 				PluginLoader.unloadPlugin(this.plugin.id)
+			else BridgeCore.deactivate()
 			lw.close()
 		},
 	},

--- a/app/renderer/src/UI/Toolbar/Category/edit.ts
+++ b/app/renderer/src/UI/Toolbar/Category/edit.ts
@@ -16,6 +16,17 @@ export const EditMenu: IAppMenu = {
 					displayIcon: 'mdi-cancel',
 					keyBinding: {
 						key: 'escape',
+						prevent: e => {
+							if (
+								e.tagName === 'INPUT' &&
+								document.activeElement === e
+							) {
+								//This might be a "little" bit hacky (because this function shouldn't have side effects) but it works :)
+								e.blur()
+								return true
+							}
+							return false
+						},
 					},
 					onClick: () => TabSystem.setCurrentFileNav('global'),
 				},

--- a/app/renderer/src/UI/Windows/Project/Create/BP/Main.vue
+++ b/app/renderer/src/UI/Windows/Project/Create/BP/Main.vue
@@ -41,8 +41,8 @@
 			<p class="mt-10">
 				The target Minecraft version should be set to what version you
 				are developing for. Currently
-				<strong>{{ MC_STABLE_VERSION }}</strong> is the stable release
-				and <strong>{{ MC_BETA_VERSION }}</strong> is the beta release.
+				<strong>{{ MC_STABLE_VERSION }}</strong> is the stable release.
+				<!--and <strong>{{ MC_BETA_VERSION }}</strong> is the beta release.-->
 			</p>
 			<v-select
 				background-color="background"

--- a/app/renderer/src/autoCompletions/Provider.ts
+++ b/app/renderer/src/autoCompletions/Provider.ts
@@ -264,12 +264,13 @@ class Provider {
 						Omega.walk(object[key].$if)
 					)
 						return key.substring(key.indexOf('.') + 1, key.length)
+					return undefined
 				} else if (key.startsWith('$versioned_template.')) {
-					const {
-						object: tmpObject,
-						value: tmpValue,
-					} = compileVersionedTemplate(object[key])
+					const { object: tmpObject } = compileVersionedTemplate(
+						object[key]
+					)
 
+					// Check for value is not needed because tmpObject is only undefined when value is also undefined
 					if (tmpObject === undefined) return undefined
 					return key.substring(key.indexOf('.') + 1, key.length)
 				} else if (key.startsWith('@import.value')) {

--- a/app/renderer/src/autoCompletions/components/VersionedTemplate/Common.ts
+++ b/app/renderer/src/autoCompletions/components/VersionedTemplate/Common.ts
@@ -6,7 +6,8 @@ import ProjectConfig from '../../../Project/Config'
 import Provider from '../../Provider'
 
 interface IVersionedTemplate {
-	$if: string
+	$if?: string
+	$legacy_if?: string //Allows usage of legacy dynamic_template $if hooks into the DYNAMIC lib
 	$data: any
 }
 
@@ -22,8 +23,11 @@ export function compileVersionedTemplate(template: IVersionedTemplate[]) {
 		resValue: string[] = []
 	let hasTruthyCondition = false
 
-	for (let { $if, $data } of template) {
-		if (!$if || compileCondition($if)) {
+	for (let { $if, $legacy_if, $data } of template) {
+		if (
+			(!$if || compileCondition($if)) &&
+			(!$legacy_if || Omega.walk($legacy_if))
+		) {
 			hasTruthyCondition = true
 
 			if (typeof $data === 'string') {

--- a/app/renderer/src/bridgeCore/BlockHandler.ts
+++ b/app/renderer/src/bridgeCore/BlockHandler.ts
@@ -1,0 +1,18 @@
+import { set } from '../Utilities/useAttr'
+import { OnSaveData } from './main'
+import { iterateEvents } from './events/iterate'
+
+export default async function BlockHandler({
+	file_uuid,
+	data,
+	file_name,
+}: OnSaveData) {
+	//DATA
+	let block = data['minecraft:block']
+	if (!block) return
+	set(block, 'components', {})
+	set(block, 'description', {})
+	set(block, 'events', {})
+
+	await iterateEvents(file_uuid, file_name, block.events)
+}

--- a/app/renderer/src/bridgeCore/EntityHandler.ts
+++ b/app/renderer/src/bridgeCore/EntityHandler.ts
@@ -9,7 +9,13 @@ import { transformTag } from './TagHandler'
 import LightningCache from '../editor/LightningCache'
 import FileType from '../editor/FileType'
 import { OnSaveData } from './main'
-import { transformJsonCommands } from './functions/transformJson'
+import {
+	transformJsonCommands,
+	transformRunCommands,
+} from './functions/transformJson'
+import { createErrorNotification } from '../AppCycle/Errors'
+import ProjectConfig from '../Project/Config'
+import { compare } from 'compare-versions'
 
 let COM_ID_COUNTER = 0
 let A_C: AnimationController
@@ -23,8 +29,16 @@ async function transformEvent(
 		events,
 		file_name,
 		file_uuid,
+		eventName,
+		formatVersion,
 	}: Partial<
-		OnSaveData & { component_groups: any; description: any; events: any }
+		OnSaveData & {
+			component_groups: any
+			description: any
+			events: any
+			eventName: string
+			formatVersion: string
+		}
 	>
 ) {
 	//SPELL EFFECTS
@@ -60,79 +74,101 @@ async function transformEvent(
 
 	//EXECUTE COMMANDS
 	let { commands: e_c } = use(event, 'execute') || {}
-	if (e_c !== undefined) {
-		let e_c_group = `execute_command_id_${++COM_ID_COUNTER}`
+	if (typeof e_c === 'string') e_c = [e_c]
+	if (e_c !== undefined && Array.isArray(e_c)) {
+		if (compare(formatVersion, '1.16.100', '<')) {
+			let e_c_group = `execute_command_id_${++COM_ID_COUNTER}`
 
-		if (!COMMAND_ANIM_REGISTERED) {
-			set(description, 'scripts/animate', ['bridge_execute_commands'])
-			COMMAND_ANIM_REGISTERED = true
-		}
-
-		set(description, 'animations', {
-			bridge_execute_commands: `controller.animation.bridge_${file_name}.execute_commands`,
-		})
-		set(component_groups, `bridge:${e_c_group}`, {
-			'minecraft:skin_id': {
-				value: COM_ID_COUNTER,
-			},
-		})
-		set(component_groups, 'bridge:execute_no_command', {
-			'minecraft:skin_id': {
-				value: 0,
-			},
-		})
-		set(event, 'add/component_groups', [`bridge:${e_c_group}`])
-		set(events, 'bridge:remove_command_id_' + COM_ID_COUNTER, {
-			add: {
-				component_groups: ['bridge:execute_no_command'],
-			},
-			remove: {
-				component_groups: [`bridge:${e_c_group}`],
-			},
-		})
-
-		set(
-			A_C,
-			`animation_controllers/controller.animation.bridge_${file_name}.execute_commands/states`,
-			{
-				default: {
-					transitions: [
-						{ [e_c_group]: `query.skin_id == ${COM_ID_COUNTER}` },
-					],
-				},
-				[e_c_group]: {
-					transitions: [
-						{ default: `query.skin_id != ${COM_ID_COUNTER}` },
-					],
-					on_entry: (
-						await transformJsonCommands(file_uuid, e_c)
-					).concat(['@s bridge:remove_command_id_' + COM_ID_COUNTER]),
-				},
+			if (!COMMAND_ANIM_REGISTERED) {
+				set(description, 'scripts/animate', ['bridge_execute_commands'])
+				COMMAND_ANIM_REGISTERED = true
 			}
+
+			set(description, 'animations', {
+				bridge_execute_commands: `controller.animation.bridge_${file_name}.execute_commands`,
+			})
+			set(component_groups, `bridge:${e_c_group}`, {
+				'minecraft:skin_id': {
+					value: COM_ID_COUNTER,
+				},
+			})
+			set(component_groups, 'bridge:execute_no_command', {
+				'minecraft:skin_id': {
+					value: 0,
+				},
+			})
+			set(event, 'add/component_groups', [`bridge:${e_c_group}`])
+			set(events, 'bridge:remove_command_id_' + COM_ID_COUNTER, {
+				add: {
+					component_groups: ['bridge:execute_no_command'],
+				},
+				remove: {
+					component_groups: [`bridge:${e_c_group}`],
+				},
+			})
+
+			set(
+				A_C,
+				`animation_controllers/controller.animation.bridge_${file_name}.execute_commands/states`,
+				{
+					default: {
+						transitions: [
+							{
+								[e_c_group]: `query.skin_id == ${COM_ID_COUNTER}`,
+							},
+						],
+					},
+					[e_c_group]: {
+						transitions: [
+							{ default: `query.skin_id != ${COM_ID_COUNTER}` },
+						],
+						on_entry: (
+							await transformJsonCommands(file_uuid, e_c)
+						).concat([
+							'@s bridge:remove_command_id_' + COM_ID_COUNTER,
+						]),
+					},
+				}
+			)
+		} else {
+			event.run_commands = await transformRunCommands(
+				file_uuid,
+				e_c.map(c => (c[0] === '/' ? c.slice(1) : c))
+			)
+		}
+	} else if (e_c !== undefined) {
+		createErrorNotification(
+			new Error(
+				`Invalid execute>commands syntax: Expected array, found ${typeof e_c}! (Path: ${file_name} - ${eventName})`
+			)
 		)
 	}
 
 	if (event.sequence !== undefined)
 		await Promise.all(
-			event.sequence.map((e: any) =>
+			event.sequence.map((e: any, i: number) =>
 				transformEvent(e, {
 					component_groups,
 					description,
 					events,
 					file_name,
 					file_uuid,
+					eventName: `${eventName}>sequence>${i}`,
+					formatVersion,
 				})
 			)
 		)
 	if (event.randomize !== undefined)
 		await Promise.all(
-			event.randomize.map((e: any) =>
+			event.randomize.map((e: any, i: number) =>
 				transformEvent(e, {
 					component_groups,
 					description,
 					events,
 					file_name,
 					file_uuid,
+					eventName: `${eventName}>randomize>${i}`,
+					formatVersion,
 				})
 			)
 		)
@@ -177,6 +213,8 @@ export default async function EntityHandler({
 	file_path,
 	simulated_call,
 }: OnSaveData) {
+	let formatVersion =
+		data.format_version || (await ProjectConfig.formatVersion)
 	let entity = data['minecraft:entity']
 	if (!entity) return
 	set(entity, 'component_groups', {})
@@ -194,12 +232,16 @@ export default async function EntityHandler({
 			events,
 			file_uuid,
 			file_name: file_name.replace('.json', ''),
+			eventName: e,
+			formatVersion,
 		})
 
-	await A_C.save(
-		join(
-			CURRENT.PROJECT_PATH,
-			`animation_controllers/bridge/commands_${file_name}`
+	// The execute>commands syntax only needs an animation controller on Minecraft releases before v1.16.100
+	if (compare(formatVersion, '1.16.100', '<'))
+		await A_C.save(
+			join(
+				CURRENT.PROJECT_PATH,
+				`animation_controllers/bridge/commands_${file_name}`
+			)
 		)
-	)
 }

--- a/app/renderer/src/bridgeCore/ItemHandler.ts
+++ b/app/renderer/src/bridgeCore/ItemHandler.ts
@@ -5,6 +5,7 @@ import { set } from '../Utilities/useAttr'
 import ItemEquippedSensor from './item/ItemEquippedSensor'
 import { OnSaveData } from './main'
 import { promises as fs } from 'fs'
+import { iterateEvents } from './events/iterate'
 declare const __static: string
 
 export type ItemComponentData = Partial<
@@ -48,7 +49,11 @@ export function transformComponents({
 	return false
 }
 
-export default async function ItemHandler({ file_uuid, data }: OnSaveData) {
+export default async function ItemHandler({
+	file_uuid,
+	data,
+	file_name,
+}: OnSaveData) {
 	//FILE PATHS
 	let player_file_path = path.join(
 		CURRENT.PROJECT_PATH,
@@ -75,7 +80,8 @@ export default async function ItemHandler({ file_uuid, data }: OnSaveData) {
 	if (!item) return
 	set(item, 'components', {})
 	set(item, 'description', {})
-	let { components, description } = item
+	set(item, 'events', {})
+	let { components, description, events } = item
 
 	//ADDITIONAL FILES
 	let PLAYER_MASK = await JSONFileMasks.get(player_file_path)
@@ -111,4 +117,7 @@ export default async function ItemHandler({ file_uuid, data }: OnSaveData) {
 		JSONFileMasks.apply(player_file_path),
 		JSONFileMasks.generateFromMask(a_c_file_path, ['default/on_entry']),
 	])
+
+	// Needs to be after player file mask so the lightning cache entries actually get added to the item, not the player
+	await iterateEvents(file_uuid, file_name, events)
 }

--- a/app/renderer/src/bridgeCore/events/iterate.ts
+++ b/app/renderer/src/bridgeCore/events/iterate.ts
@@ -1,0 +1,84 @@
+import { createErrorNotification } from '../../AppCycle/Errors'
+import { transformRunCommands } from '../functions/transformJson'
+
+interface IEvent {
+	run_command?: {
+		command?: string | string[]
+		target?: string
+	}
+	sequence?: IEvent[]
+	randomize?: IEvent[]
+}
+
+export async function iterateEvents(
+	fileUUID: string,
+	fileName: string,
+	events: Record<string, unknown>
+) {
+	for (const eventName in events) {
+		await compileEvent(
+			fileUUID,
+			fileName,
+			eventName,
+			events[eventName] as IEvent
+		)
+	}
+}
+
+export async function compileEvent(
+	fileUUID: string,
+	fileName: string,
+	eventName: string,
+	event: IEvent
+) {
+	if (event.run_command !== undefined) {
+		let { command } = event.run_command
+		if (typeof command === 'string') command = [command]
+
+		if (Array.isArray(command))
+			event.run_command.command = await transformRunCommands(
+				fileUUID,
+				command
+			)
+		else
+			createErrorNotification(
+				new Error(
+					`Invalid run_command>command type: Expected array, found ${typeof command}! (Path: ${fileName} - ${eventName})`
+				)
+			)
+	}
+
+	if (event.sequence !== undefined && Array.isArray(event.sequence)) {
+		event.sequence.forEach((sequenceEntry, i) =>
+			compileEvent(
+				fileUUID,
+				fileName,
+				`${eventName}>sequence>${i}`,
+				sequenceEntry
+			)
+		)
+	} else if (event.sequence !== undefined) {
+		createErrorNotification(
+			new Error(
+				`Invalid event>sequence type: Expected array, found ${typeof event.sequence}! (Path: ${fileName} - ${eventName})`
+			)
+		)
+	}
+
+	if (event.randomize !== undefined && Array.isArray(event.randomize)) {
+		event.randomize.forEach((randomizeEntry, i) =>
+			compileEvent(
+				fileUUID,
+				fileName,
+				`${eventName}>randomize>${i}`,
+				randomizeEntry
+			)
+		)
+	} else if (event.randomize !== undefined) {
+		createErrorNotification(
+			new Error(
+				`Invalid event>randomize type: Expected array, found ${typeof event.randomize}! (Path: ${fileName} - ${eventName})`
+			)
+		)
+	}
+}

--- a/app/renderer/src/bridgeCore/main.ts
+++ b/app/renderer/src/bridgeCore/main.ts
@@ -7,11 +7,9 @@ import OmegaCache from '../editor/OmegaCache'
 import { JSONFileMasks } from '../editor/JSONFileMasks'
 import path from 'path'
 import CORE_FILES from './CORE_FILES'
-
 import EntityHandler, { handleTags } from './EntityHandler'
 import ItemHandler from './ItemHandler'
 import TagHandler from './TagHandler'
-
 import ComponentRegistry from '../plugins/CustomComponents'
 import MapAreaHandler from './MapAreaHandler'
 import trash from 'trash'
@@ -23,6 +21,7 @@ import { updateCustomCommand } from './update/commands'
 import AnimationHandler from './AnimationHandler'
 import AnimationControllerHandler from './AnimationControllerHandler'
 import { createInformationWindow } from '../UI/Windows/Common/CommonDefinitions'
+import BlockHandler from './BlockHandler'
 
 export interface OnSaveData {
 	file_path: string
@@ -221,6 +220,7 @@ BridgeCore.setSaveHandler('animation', AnimationHandler)
 BridgeCore.setSaveHandler('animation_controller', AnimationControllerHandler)
 BridgeCore.setSaveHandler('entity', EntityHandler)
 BridgeCore.setSaveHandler('item', ItemHandler)
+BridgeCore.setSaveHandler('block', BlockHandler)
 BridgeCore.setSaveHandler('entity_tag', TagHandler)
 BridgeCore.setSaveHandler('bridge_map_area', MapAreaHandler)
 BridgeCore.setTextSaveHandler('function', parseFunction)

--- a/app/renderer/src/bridgeCore/main.ts
+++ b/app/renderer/src/bridgeCore/main.ts
@@ -41,6 +41,8 @@ export const UI_DATA = {
 		'A core library which improves your add-on experience with custom syntax.',
 	version: '1.0.0',
 	id: 'bridge.core',
+	basePath: 'bridge.core',
+	pluginFolder: 'bridge.core',
 }
 
 export type TTextSaveHandler = (

--- a/app/renderer/src/bridgeCore/main.ts
+++ b/app/renderer/src/bridgeCore/main.ts
@@ -41,8 +41,6 @@ export const UI_DATA = {
 		'A core library which improves your add-on experience with custom syntax.',
 	version: '1.0.0',
 	id: 'bridge.core',
-	basePath: 'bridge.core',
-	pluginFolder: 'bridge.core',
 }
 
 export type TTextSaveHandler = (

--- a/app/renderer/src/constants.ts
+++ b/app/renderer/src/constants.ts
@@ -36,7 +36,7 @@ export * from '../../shared/DefaultDir'
 export const BASE_PATH = BP_BASE_PATH
 
 export const MC_BETA_VERSION = '1.16.100'
-export const MC_STABLE_VERSION = '1.16.0'
+export const MC_STABLE_VERSION = '1.16.100'
 
 export const browser_window = remote.getCurrentWindow()
 

--- a/app/renderer/src/editor/LightningCache.ts
+++ b/app/renderer/src/editor/LightningCache.ts
@@ -229,7 +229,7 @@ export default class LightningCache {
 				}) => {
 					if (iterate !== undefined) {
 						;(content.get(iterate)?.children ?? []).forEach(c =>
-							this.storeInCahe(
+							this.storeInCache(
 								cache,
 								c,
 								path,
@@ -239,7 +239,7 @@ export default class LightningCache {
 							)
 						)
 					} else if (path !== undefined) {
-						this.storeInCahe(
+						this.storeInCache(
 							cache,
 							content,
 							path,
@@ -284,7 +284,7 @@ export default class LightningCache {
 		if (except) cache[except] = []
 	}
 
-	static storeInCahe(
+	static storeInCache(
 		cache: { [cacheKey: string]: string[] },
 		content: JSONTree,
 		path: string,

--- a/app/renderer/src/plugins/CustomCommands.ts
+++ b/app/renderer/src/plugins/CustomCommands.ts
@@ -89,6 +89,7 @@ export async function registerCustomCommand(
 							'animation_controller',
 							'animation',
 							'item',
+							'block',
 						],
 						['custom_commands'],
 						Command.command_name

--- a/app/renderer/src/plugins/CustomComponents.ts
+++ b/app/renderer/src/plugins/CustomComponents.ts
@@ -126,6 +126,7 @@ export default class ComponentRegistry {
 		//SETUP PLUGIN API ENV
 		ContextEnv.value = {
 			entityIdentifier,
+			formatVersion: data.format_version,
 		}
 
 		const usedComponents: string[] = []
@@ -193,6 +194,7 @@ export default class ComponentRegistry {
 		//SETUP PLUGIN API ENV
 		ContextEnv.value = {
 			blockIdentifier,
+			formatVersion: data.format_version,
 		}
 
 		const usedComponents: string[] = []

--- a/app/renderer/src/plugins/PluginLoader.ts
+++ b/app/renderer/src/plugins/PluginLoader.ts
@@ -170,11 +170,6 @@ export default class PluginLoader {
 		pluginFolder: string,
 		unloadedPlugins: string[]
 	) {
-		if (basePath === 'bridge.core') {
-			BridgeCore.activate()
-			return
-		}
-
 		let pluginPath = path.join(basePath, 'plugins', pluginFolder)
 		if ((await fs.lstat(pluginPath)).isFile()) {
 			if (path.extname(pluginPath) === '.js') {

--- a/app/renderer/src/plugins/PluginLoader.ts
+++ b/app/renderer/src/plugins/PluginLoader.ts
@@ -72,6 +72,7 @@ export default class PluginLoader {
 	}
 
 	static async unloadPlugin(pluginId: string) {
+		if (pluginId === 'bridge.core') BridgeCore.deactivate()
 		clearDisposables(pluginId)
 	}
 
@@ -169,6 +170,11 @@ export default class PluginLoader {
 		pluginFolder: string,
 		unloadedPlugins: string[]
 	) {
+		if (basePath === 'bridge.core') {
+			BridgeCore.activate()
+			return
+		}
+
 		let pluginPath = path.join(basePath, 'plugins', pluginFolder)
 		if ((await fs.lstat(pluginPath)).isFile()) {
 			if (path.extname(pluginPath) === '.js') {

--- a/app/shared/app_version.ts
+++ b/app/shared/app_version.ts
@@ -1,4 +1,4 @@
 /**
  * Current bridge. app version
  */
-export default 'v1.7.14'
+export default 'v1.7.15'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridge",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "author": "solvedDev <solveddev@gmail.com>",
   "description": "A powerful add-on editor",
   "license": "GNU",

--- a/static/lightning_cache/block.json
+++ b/static/lightning_cache/block.json
@@ -1,6 +1,7 @@
 [ 
     { "key": "identifiers", "path": "minecraft:block/description/identifier" },
     { "key": "custom_components", "hook": "block.custom_components" },
+    { "key": "custom_commands", "hook": "json.custom_commands" }, 
     { "key": "events", "path": "minecraft:block/events" },
     { "key": "recipe_tags", "path": "minecraft:block/components/minecraft:crafting_table/crafting_tags"}
 ]


### PR DESCRIPTION
## Features:
- Custom components can now access current file format version for building more robust code that works for multiple Minecraft versions
- Better handling of `execute>commands` custom syntax
  - Now compiles simple strings without an error
  - Better error reports for invalid syntax
  - On "v1.16.100" file format versions, this syntax now compiles to Minecraft's native `run_command` event response
- Added support for custom commands inside of entity, block & item `run_command` event response

## Changes:
- Added new argument to `$versioned_template`s to easily combine them with `$dynamic_template`s
- Improved "escape" behavior:
  - Now first removes focus from inputs without unselecting the current node
  - If no input is focused, bridge. will unselect the current node
- Updated project target version description

## Fixes:
- Fixed project refreshing
- Fixed bridge. Core built-in plugin not activating/deactivating correctly
- Fixed `$dynamic_template` with `$if` showing up in auto-completions if `$if` evaluates to `false`