### PR TITLE
Update static/presets/ore_preset/feature.json

### DIFF
--- a/static/presets/ore_preset/feature.json
+++ b/static/presets/ore_preset/feature.json
@@ -1,53 +1,57 @@
 {
-	"format_version": "1.13.0",
+	"format_version": "1.17.0",
 	"minecraft:ore_feature": {
 		"description": {
 			"identifier": "{{PROJ_PREFIX}}:{{IDENTIFIER}}_feature"
 		},
 		"count": 9,
-		"places_block": "{{PROJ_PREFIX}}:{{IDENTIFIER}}",
-		"may_replace": [
+		"replace_rules": [
 			{
-				"name": "minecraft:stone",
-				"states": {
-					"stone_type": "andesite"
-				}
-			},
-			{
-				"name": "minecraft:stone",
-				"states": {
-					"stone_type": "andesite_smooth"
-				}
-			},
-			{
-				"name": "minecraft:stone",
-				"states": {
-					"stone_type": "diorite"
-				}
-			},
-			{
-				"name": "minecraft:stone",
-				"states": {
-					"stone_type": "diorite_smooth"
-				}
-			},
-			{
-				"name": "minecraft:stone",
-				"states": {
-					"stone_type": "granite"
-				}
-			},
-			{
-				"name": "minecraft:stone",
-				"states": {
-					"stone_type": "granite_smooth"
-				}
-			},
-			{
-				"name": "minecraft:stone",
-				"states": {
-					"stone_type": "stone"
-				}
+				"places_block": "{{PROJ_PREFIX}}:{{IDENTIFIER}}",
+				"may_replace": [
+					{
+						"name": "minecraft:stone",
+						"states": {
+							"stone_type": "andesite"
+						}
+					},
+					{
+						"name": "minecraft:stone",
+						"states": {
+							"stone_type": "andesite_smooth"
+						}
+					},
+					{
+						"name": "minecraft:stone",
+						"states": {
+							"stone_type": "diorite"
+						}
+					},
+					{
+						"name": "minecraft:stone",
+						"states": {
+							"stone_type": "diorite_smooth"
+						}
+					},
+					{
+						"name": "minecraft:stone",
+						"states": {
+							"stone_type": "granite"
+						}
+					},
+					{
+						"name": "minecraft:stone",
+						"states": {
+							"stone_type": "granite_smooth"
+						}
+					},
+					{
+						"name": "minecraft:stone",
+						"states": {
+							"stone_type": "stone"
+						}
+					}
+				]
 			}
 		]
 	}


### PR DESCRIPTION
Update the ore preset to use valid Bedrock Edition 1.17.0 syntax.

## Motivation and Context
The original ore preset used invalid syntax.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have tested my changes and confirmed that they are working
