### PR TITLE
v1.8.0

### DIFF
--- a/app/renderer/src/AppCycle/startUp.ts
+++ b/app/renderer/src/AppCycle/startUp.ts
@@ -62,7 +62,6 @@ export default async function startUp() {
 	}
 
 	// Prompt to migrate to v2
-	createMigrationPromptWindow()
 	createNotification({
 		icon: 'mdi-update',
 		message: 'bridge. v2',

--- a/app/renderer/src/UI/Windows/Migration/definition.ts
+++ b/app/renderer/src/UI/Windows/Migration/definition.ts
@@ -6,7 +6,7 @@ export function createMigrationPromptWindow() {
 	createConfirmWindow(
 		'bridge. v2 is now available! To begin migrating to bridge. v2, select the "Continue" option below.',
 		'Continue',
-		'Discard',
+		'Later',
 		() => MigrationWindow.open(),
 		() => {}
 	)

--- a/app/shared/app_version.ts
+++ b/app/shared/app_version.ts
@@ -1,4 +1,4 @@
 /**
  * Current bridge. app version
  */
-export default 'v1.7.18'
+export default 'v1.8.0-pre1'

--- a/app/shared/app_version.ts
+++ b/app/shared/app_version.ts
@@ -1,4 +1,4 @@
 /**
  * Current bridge. app version
  */
-export default 'v1.8.0-pre1'
+export default 'v1.8.0'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridge",
-  "version": "1.8.0-pre1",
+  "version": "1.8.0",
   "private": true,
   "author": "solvedDev <solveddev@gmail.com>",
   "description": "A powerful add-on editor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridge",
-  "version": "1.7.18",
+  "version": "1.8.0-pre1",
   "author": "solvedDev <solveddev@gmail.com>",
   "description": "A powerful add-on editor",
   "license": "GNU",

--- a/static/file_creator/feature.json
+++ b/static/file_creator/feature.json
@@ -126,6 +126,142 @@
                 },
                 "features": {}
             }
+        },
+        "Blank Cave Carver Feature": {
+            "format_version": {},
+            "minecraft:cave_carver_feature": {
+                "description": {
+                    "identifier": {}
+                },
+                "fill_with": {},
+                "width_modifier": {}
+            }
+        },
+        "Blank Hell Cave Carver Feature": {
+            "format_version": {},
+            "minecraft:hell_cave_carver_feature": {
+                "description": {
+                    "identifier": {}
+                },
+                "fill_with": {},
+                "width_modifier": {}
+            }
+        },
+        "Blank Underwater Cave Carver Feature": {
+            "format_version": {},
+            "minecraft:underwater_cave_carver_feature": {
+                "description": {
+                    "identifier": {}
+                },
+                "fill_with": {},
+                "width_modifier": {},
+                "replace_air_with": {}
+            }
+        },
+        "Blank Growing Plant Feature": {
+            "format_version": {},
+            "minecraft:growing_plant_feature": {
+                "description": {
+                    "identifier": {}
+                },
+                "height_distribution": {},
+				"allow_water": {},
+				"growth_direction": {},
+				"body_blocks": {},
+				"head_blocks": {}
+            }
+        },
+        "Blank Snap to Surface Feature": {
+            "format_version": {},
+            "minecraft:snap_to_surface_feature": {
+                "description": {
+					"identifier": {}
+				},
+				"feature_to_snap": {},
+				"vertical_search_range": {},
+				"surface": {}
+            }
+        },
+        "Blank Vegetation Patch Feature": {
+            "format_version": {},
+            "minecraft:vegetation_patch_feature": {
+                "description": {
+					"identifier": {}
+				},
+				"replaceable_blocks": {},
+				"ground_block": {},
+				"vegetation_feature": {},
+				"surface": {},
+				"depth": {},
+				"extra_deep_block_chance": {},
+				"vertical_range": {},
+				"vegetation_chance": {},
+				"horizontal_radius": {},
+				"extra_edge_column_chance": {}
+            }
+        },
+        "Blank Geode Feature": {
+            "format_version": {},
+            "minecraft:geode_feature": {
+                "description": {
+					"identifier": {}
+				},
+				"filler": {},
+				"inner_layer": {},
+				"alternate_inner_layer": {},
+				"middle_layer": {},
+				"outer_layer": {},
+				"inner_placements": {},
+				"min_outer_wall_distance": {},
+				"max_outer_wall_distance": {},
+				"max_radius": {},
+				"invalid_blocks_threshold": {}
+            }
+        },
+        "Blank Multiface Feature": {
+            "format_version": {},
+            "minecraft:multiface_feature": {
+                "description": {
+					"identifier": {}
+				},
+				"places_block": {},
+				"search_range": {},
+				"can_place_on_floor": {},
+				"can_place_on_ceiling": {},
+				"can_place_on_wall": {},
+				"chance_of_spreading": {},
+				"can_place_on": {}
+            }
+        },
+        "Blank Beards and Shavers Feature": {
+            "format_version": {},
+            "minecraft:beards_and_shavers": {
+                "description": {
+					"identifier": {}
+				},
+				"places_feature": {},
+				"bounding_box_min": {},
+				"bounding_box_max": {},
+				"surface_block_type": {},
+				"subsurface_block_type": {},
+				"beard_raggedness_min": {},
+				"beard_raggedness_max": {}
+            }
+        },
+        "Blank Rect Layout Feature": {
+            "format_version": {},
+            "minecraft:rect_layout": {
+                "description": {
+					"identifier": {}
+				},
+				"ratio_of_empty_space": {},
+				"feature_areas": [
+					{
+						"feature": {},
+						"area_dimensions": {}
+					}
+				]
+            }
         }
     }
 }


### PR DESCRIPTION
**This release allows you to migrate your bridge. v1 projects to bridge. v2!**
Below are the changes since v1.8.0-pre1:

# Changes
- Updated compiler and project config creation
- Changed v2 link to new URL
- You can now transfer your bridge. v1 projects to an already existing bridge. v2 directory

# Fixes
- Fixed transforming arrays from bridge.'s cache
- Fixed typo in compiler config
- Fixed translation error in compiler config